### PR TITLE
feat: add jwt and keycloak authenticated identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 # Vagrant VM (temporary files)
 .vagrant
 package-lock.json
+
+.env
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm install git+https://github.com/myDevicesIoT/hapi-auth-jwtcloak
 Parameter Name | Description
 --- | ---
 `setAsDefaultAuth` | `Boolean` if true, sets `jwt` as the default Hapi authentication strategy when the authentication strategy is not defined for a Hapi route config.
+`strategy` | `string` sets the hapi strategy name to use on route configs, defaults to `jwt`.
+`issuers[].defaultScopes` | `string[]` adds default scope(s) to the decoded credentials
 
 <h2>Example:</h2>
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Controller = require('./lib/controller');
+const pkg = require('./package.json');
 
 exports.register = (server, options, next) => {
     const jwtController = new Controller(options);
@@ -7,9 +8,10 @@ exports.register = (server, options, next) => {
         if (err) {
             return next(err);
         }
+        const strategy = options.strategy ? options.strategy : 'jwt';
 
         //JWT validation setup
-        server.auth.strategy('jwt', 'jwt', {
+        server.auth.strategy(strategy, 'jwt', {
             //returns headers & signature
             complete: true, 
             verifyFunc: verifyFunc.bind(jwtController)
@@ -20,10 +22,6 @@ exports.register = (server, options, next) => {
         }
         return next();
     });
-    
 }
-  
-exports.register.attributes = {
-    name: 'hapi-auth-jwtcloak',
-    version: '1.0.3'
-};
+
+exports.register.attributes = { pkg };

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -33,7 +33,6 @@ JWTController.prototype.keycloakHandler = function(decoded, req, callback) {
   
   let issuerOptions = _.find(this.issuers, { issuer: issuer });
 
-  //
   if (!issuerOptions.options.usePublicKey) {
     // handle validation using keycloak introespect
     return this.keycloakIntrospect(payload, issuerOptions, token, callback);
@@ -45,8 +44,15 @@ JWTController.prototype.keycloakHandler = function(decoded, req, callback) {
       data = JWT.verify(token, key);
 
       if (issuerOptions.options.filterFunc) {
-        console.log(issuerOptions.options.filterFunc);
         data = issuerOptions.options.filterFunc(data);
+      }
+      data.isKeycloakAuthenticated = true;
+
+      if (!_.isNil(issuerOptions.defaultScopes)) {
+        if (_.isNil(data.scope)) {
+          data.scope = [];
+        }
+        data.scope = _.uniq(data.scope.concat(issuerOptions.defaultScopes))
       }
 
       callback(null, true, data);
@@ -72,7 +78,6 @@ JWTController.prototype.keycloakHandler = function(decoded, req, callback) {
 }
 
 JWTController.prototype.keycloakIntrospect = function(payload, data, token, callback) {
-  console.log('keycloakIntrospect');
   const basicToken = Buffer.from(`${data.options.clientId}:${data.options.clientSecret}`).toString('base64');
   
   request.post({
@@ -98,9 +103,15 @@ JWTController.prototype.keycloakIntrospect = function(payload, data, token, call
     if (!json.active) {
       return callback(Boom.unauthorized(), false);
     }
-    console.log('introspect %d', Date.now());
-    //reassign user_id for backwards compatibility
-    payload.user_id = payload.sub;
+
+    payload.isKeycloakAuthenticated = true;
+
+    if (!_.isNil(data.defaultScopes)) {
+      if (_.isNil(payload.scope)) {
+        payload.scope = [];
+      }
+      payload.scope = _.uniq(payload.scope.concat(data.defaultScopes));
+    }
 
     return callback(null, true, payload);
   });
@@ -139,6 +150,7 @@ JWTController.prototype.verifyFunc = function(decoded, req, callback) {
     if (issuer.options.filterFunc) {
       payload = issuer.options.filterFunc(payload);
     }
+    payload.isJwtAuthenticated = true;
 
     return callback(null, true, payload);
   });


### PR DESCRIPTION
Decoded token changes:
* `isKeycloakAuthenticated` is now provided in credentials to indicate a keycloak authorized token
* `isJwtAuthenticated` is now provided in credentials to indicate a JWT authorized token

Config option changes:
* `issuers[].defaultScopes` adds values to `scope` in credentials
* `strategy` allows renaming of jwt auth scheme

