### PR TITLE
fix: convert string to array

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -55,6 +55,11 @@ JWTController.prototype.keycloakHandler = function(decoded, req, callback) {
         data.scope = _.uniq(data.scope.concat(issuerOptions.defaultScopes))
       }
 
+      const tokenScope = _.get(payload, 'scope', null);
+      if (typeof tokenScope === 'string') {
+        data.scope = payload.scope.split(' ');
+      }
+
       callback(null, true, data);
     } catch (err) {
       callback(null, false);
@@ -111,6 +116,11 @@ JWTController.prototype.keycloakIntrospect = function(payload, data, token, call
         payload.scope = [];
       }
       payload.scope = _.uniq(payload.scope.concat(data.defaultScopes));
+    }
+
+    const tokenScope = _.get(payload, 'scope', null);
+    if (typeof tokenScope === 'string') {
+      payload.scope = payload.scope.split(' ');
     }
 
     return callback(null, true, payload);


### PR DESCRIPTION
Keycloak adds scope as a space delimited list and needs to be converted to array for Hapi.